### PR TITLE
Qiita Moduleのリファクタリング

### DIFF
--- a/web/modules/custom/qiita/qiita.services.yml
+++ b/web/modules/custom/qiita/qiita.services.yml
@@ -1,3 +1,7 @@
 services:
+  qiita.feed_fetcher:
+    class: Drupal\qiita\Service\FeedFetcherService
+    arguments:
+      - '@http_client'
   qiita.feed_parser:
     class: Drupal\qiita\Service\QiitaFeedParserService

--- a/web/modules/custom/qiita/qiita.services.yml
+++ b/web/modules/custom/qiita/qiita.services.yml
@@ -1,0 +1,3 @@
+services:
+  qiita.feed_parser:
+    class: Drupal\qiita\Service\QiitaFeedParserService

--- a/web/modules/custom/qiita/src/Controller/QiitaController.php
+++ b/web/modules/custom/qiita/src/Controller/QiitaController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Drupal\qiita\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\qiita\Interface\FeedFetcherInterface;
 use Drupal\qiita\Interface\FeedParserInterface;
-use GuzzleHttp\Client;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -23,9 +23,9 @@ final class QiitaController extends ControllerBase {
   private const QIITA_URL = 'https://qiita.com/';
 
   /**
-   * Http client.
+   * Feed Fetcher.
    */
-  protected Client $httpClient;
+  protected FeedFetcherInterface $feedFetcher;
 
   /**
    * Feed Parser.
@@ -33,18 +33,23 @@ final class QiitaController extends ControllerBase {
   protected FeedParserInterface $feedParser;
 
   /**
+   * CacheKey.
+   */
+  protected string $cacheKey;
+
+  /**
    * Constructor.
    *
-   * @param \GuzzleHttp\Client $http_client
-   *   Guzzle.
+   * @param \Drupal\qiita\Service\Interface\FeedFetcherInterface $feed_fetcher
+   *   Feed Fetcher.
    * @param \Drupal\qiita\Service\Interface\FeedParserInterface $feed_parser
    *   Feed Parser.
    */
   public function __construct(
-    Client $http_client,
+    FeedFetcherInterface $feed_fetcher,
     FeedParserInterface $feed_parser,
   ) {
-    $this->httpClient = $http_client;
+    $this->feedFetcher = $feed_fetcher;
     $this->feedParser = $feed_parser;
   }
 
@@ -53,9 +58,19 @@ final class QiitaController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('http_client'),
+      $container->get('qiita.feed_fetcher'),
       $container->get('qiita.feed_parser'),
     );
+  }
+
+  /**
+   * Set cache-key.
+   *
+   * @param string $id
+   *   Qiita account ID used to generate the cache key.
+   */
+  protected function setCacheKey(string $id): void {
+    $this->cacheKey = 'qiita:' . $id;
   }
 
   /**
@@ -68,19 +83,16 @@ final class QiitaController extends ControllerBase {
    *   The JSON response with HTML content or a 403 status code on failure.
    */
   public function __invoke(string $id) {
-    $cache_key = 'api_qiita:' . $id;
-    $cache = $this->cache()->get($cache_key);
+    // Cache.
+    $this->setCacheKey($id);
+    $cache = $this->cache()->get($this->cacheKey);
     if ($cache) {
       $data = $cache->data;
     }
     else {
       try {
-        $qiita_url = self::QIITA_URL . $id;
-        $http_request = $this->httpClient->get($qiita_url . '/feed');
-        $feed = $http_request->getBody()->getContents();
-        if (!$feed) {
-          throw new \Exception();
-        }
+        // Get request.
+        $feed = $this->feedFetcher->get(self::QIITA_URL . $id . '/feed');
         // Load and parse xml data.
         $data = $this->feedParser->loadRawFeedData($feed);
         if (!$data) {
@@ -88,24 +100,13 @@ final class QiitaController extends ControllerBase {
         }
         $data = $this->feedParser->parseXml($data);
         // Set cache.
-        $this->cache()->set($cache_key, $data, time() + 8 * 3600);
+        $this->cache()->set($this->cacheKey, $data, time() + 8 * 3600);
       }
       catch (\Exception $e) {
         return new JsonResponse([], 403);
       }
     }
     return new JsonResponse($data);
-  }
-
-  /**
-   * Get feed data.
-   */
-  protected function getFeedData(string $url) {
-    $http_request = $this->httpClient->get($url);
-    $feed = $http_request->getBody()->getContents();
-    if (!$feed) {
-      throw new \Exception();
-    }
   }
 
 }

--- a/web/modules/custom/qiita/src/Interface/FeedFetcherInterface.php
+++ b/web/modules/custom/qiita/src/Interface/FeedFetcherInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\qiita\Interface;
+
+/**
+ * Interface for fetching feed data over HTTP.
+ *
+ * This interface defines the method necessary for fetching raw feed data
+ * from a specified URL. It abstracts the functionality of making HTTP
+ * requests to retrieve feed data, allowing different implementations to
+ * utilize various HTTP clients or methods.
+ */
+interface FeedFetcherInterface {
+
+  /**
+   * Fetches raw feed data from the specified URL.
+   *
+   * This method sends an HTTP GET request to the provided URL and retrieves
+   * the feed data as a raw string. It is expected to handle HTTP specifics
+   * such as dealing with different response codes and managing exceptions
+   * related to network issues or invalid responses.
+   *
+   * @param string $url
+   *   The URL from which to fetch the feed data.
+   *
+   * @return string
+   *   The raw feed data as a string. If the fetch operation fails, it should
+   *   throw an appropriate exception or return an empty string.
+   *
+   * @throws \Exception
+   *   Throws an exception if there is any error during the fetch operation,
+   *   including but not limited to network errors, invalid URLs, or error
+   *   response codes from the server.
+   */
+  public function get(string $url): string;
+
+}

--- a/web/modules/custom/qiita/src/Interface/FeedParserInterface.php
+++ b/web/modules/custom/qiita/src/Interface/FeedParserInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\qiita\Service\Interface;
+
+/**
+ * Interface that provide to parse feed data.
+ */
+interface FeedParserInterface {
+
+  /**
+   * Parse an XML feed into a structured array.
+   *
+   * @param \SimpleXMLElement $xml
+   *   The XML data to parse, typically retrieved from a feed source.
+   *
+   * @return array
+   *   An associative array containing the parsed data.
+   */
+  public function parseXml(\SimpleXMLElement $xml): array;
+
+}

--- a/web/modules/custom/qiita/src/Interface/FeedParserInterface.php
+++ b/web/modules/custom/qiita/src/Interface/FeedParserInterface.php
@@ -1,11 +1,26 @@
 <?php
 
-namespace Drupal\qiita\Service\Interface;
+namespace Drupal\qiita\Interface;
 
 /**
  * Interface that provide to parse feed data.
  */
 interface FeedParserInterface {
+
+  /**
+   * Loads and parses raw feed data into a SimpleXMLElement.
+   *
+   * This method takes a raw XML string and converts it into a SimpleXMLElement.
+   * If the XML string is malformed or empty, the method should return false.
+   *
+   * @param string $feed
+   *   The raw feed data as a string.
+   *
+   * @return \SimpleXMLElement|false
+   *   The SimpleXMLElement object if the XML is well-formed and valid, or
+   *   false if the XML is invalid or cannot be parsed.
+   */
+  public function loadRawFeedData(string $feed): \SimpleXMLElement|false;
 
   /**
    * Parse an XML feed into a structured array.

--- a/web/modules/custom/qiita/src/Service/FeedFetcherService.php
+++ b/web/modules/custom/qiita/src/Service/FeedFetcherService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\qiita\Service;
+
+use Drupal\qiita\Interface\FeedFetcherInterface;
+use GuzzleHttp\Client;
+
+/**
+ * Service class for fetching feed data using the Guzzle HTTP client.
+ *
+ * This class implements the FeedFetcherInterface to provide a concrete
+ * method for fetching feed data over HTTP. It utilizes the Guzzle HTTP
+ * client to send GET requests and handle responses. The class is designed
+ * to manage HTTP communication and error handling effectively, encapsulating
+ * all the complexities of network interactions.
+ */
+final class FeedFetcherService implements FeedFetcherInterface {
+
+  /**
+   * The HTTP client used for making requests.
+   */
+  protected Client $httpClient;
+
+  /**
+   * Constructor.
+   *
+   * Initializes the feed fetcher service with a Guzzle HTTP client.
+   *
+   * @param \GuzzleHttp\Client $http_client
+   *   The Guzzle HTTP client instance.
+   */
+  public function __construct(
+    Client $http_client,
+  ) {
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function get(string $url): string {
+    $http_request = $this->httpClient->get($url);
+    $feed = $http_request->getBody()->getContents();
+    if (!$feed) {
+      throw new \Exception();
+    }
+    return $feed;
+  }
+
+}

--- a/web/modules/custom/qiita/src/Service/FeedParserServiceBase.php
+++ b/web/modules/custom/qiita/src/Service/FeedParserServiceBase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\qiita\Service;
+
+use Drupal\qiita\Service\Interface\FeedParserInterface;
+
+/**
+ * Abstract base class for feed parser services.
+ *
+ * Provides a common foundation for all feed parser implementations.
+ * Defines structure and method that all derived classes must implement.
+ * Ensures adherence to the FeedParserInterface with implementation of
+ * the parseXml method.
+ */
+abstract class FeedParserServiceBase implements FeedParserInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  abstract public function parseXml(\SimpleXMLElement $xml): array;
+
+}

--- a/web/modules/custom/qiita/src/Service/FeedParserServiceBase.php
+++ b/web/modules/custom/qiita/src/Service/FeedParserServiceBase.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\qiita\Service;
 
-use Drupal\qiita\Service\Interface\FeedParserInterface;
+use Drupal\qiita\Interface\FeedParserInterface;
 
 /**
  * Abstract base class for feed parser services.
@@ -13,6 +13,17 @@ use Drupal\qiita\Service\Interface\FeedParserInterface;
  * the parseXml method.
  */
 abstract class FeedParserServiceBase implements FeedParserInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function loadRawFeedData(string $feed): \SimpleXMLElement|false {
+    $data = simplexml_load_string($feed);
+    if (assert($data instanceof \SimpleXMLElement)) {
+      return $data;
+    }
+    return FALSE;
+  }
 
   /**
    * {@inheritDoc}

--- a/web/modules/custom/qiita/src/Service/GetFeedServiceBase.php
+++ b/web/modules/custom/qiita/src/Service/GetFeedServiceBase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\qiita\Service;
+
+use Drupal\qiita\Interface\FeedParserInterface;
+
+/**
+ * Abstract base class for feed parser services.
+ *
+ * Provides a common foundation for all feed parser implementations.
+ * Defines structure and method that all derived classes must implement.
+ * Ensures adherence to the FeedParserInterface with implementation of
+ * the parseXml method.
+ */
+abstract class GetFeedServiceBase implements FeedParserInterface {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function loadRawFeedData(string $feed): \SimpleXMLElement|false {
+    $data = simplexml_load_string($feed);
+    if (assert($data instanceof \SimpleXMLElement)) {
+      return $data;
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  abstract public function parseXml(\SimpleXMLElement $xml): array;
+
+}

--- a/web/modules/custom/qiita/src/Service/QiitaFeedParserService.php
+++ b/web/modules/custom/qiita/src/Service/QiitaFeedParserService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\qiita\Service;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+
+/**
+ * Provides functionality to parse Qiita XML feeds.
+ *
+ * This service is responsible for parsing XML feed data retrieved from Qiita.
+ * It converts the raw XML data into a structured array that can be easily
+ * used within Drupal. This class extends the generic FeedParserServiceBase
+ * to implement Qiita-specific parsing logic.
+ */
+final class QiitaFeedParserService extends FeedParserServiceBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function parseXml(\SimpleXMLElement $xml): array {
+    $articles = [];
+    foreach ($xml->entry as $o) {
+      // Get feed item.
+      $title = (string) $o->title;
+      $attributes = $o->link->attributes();
+      $link = (string) $attributes['href'];
+      $published = (string) $o->published;
+      if (!isset($title) || !isset($link) || !isset($published)) {
+        continue;
+      }
+      $published = new DrupalDateTime($published);
+
+      $articles[] = [
+        'title' => $title,
+        'link' => $link,
+        'published' => $published->format('c'),
+      ];
+    }
+    return [
+      'title' => (string) $xml->title,
+      'link' => (string) current($xml->link[2] ?? []),
+      'data' => $articles,
+    ];
+  }
+
+}


### PR DESCRIPTION
## Ticket
[No:23](https://www.notion.so/Qiita-Module-08654c84ae7b4bb3b66518448ce54a37?pvs=4)

## Summary
リファクタリング実施

## ChangeLog
Controller内の処理を分割し、サービス化。
### Controller
ユーザーの入力と出力のみを提供。
### QiitaFeedParserService
Qiita専用のFeed解析ロジック。
### FeedFetcherService
HttpRequestでのFetchロジック。
## Other
**ディレクトリ構成**
```txt
qiita
├── qiita.info.yml
├── qiita.routing.yml
├── qiita.services.yml
└── src
    ├── Controller
    │   └── QiitaController.php
    ├── Interface
    │   ├── FeedFetcherInterface.php
    │   └── FeedParserInterface.php
    └── Service
        ├── FeedFetcherService.php
        ├── FeedParserServiceBase.php
        ├── GetFeedServiceBase.php
        └── QiitaFeedParserService.php
```
